### PR TITLE
Added support for OFX files provided by Japanese institutios

### DIFF
--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -213,7 +213,7 @@ class OfxParser(object):
         # for 6 Nov 2010 4pm UTC-5 aka EST
         
         # Some places (e.g. Newfoundland) have non-integer offsets.
-        res = re.search("\[(?P<tz>-?\d+\.?\d*)\:\w*\]$", ofxDateTime)
+        res = re.search("\[(?P<tz>[-+]?\d+\.?\d*)\:\w*\]$", ofxDateTime)
         if res:
             tz = float(res.group('tz'))
         else:

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -170,6 +170,8 @@ class TestStringToDate(TestCase):
             datetime(2012, 04, 12, 17, 30))
         self.assertEquals( OfxParser.parseOfxDateTime('20120412120000 [-5:XXX]'),
             datetime(2012, 04, 12, 17))
+        self.assertEquals( OfxParser.parseOfxDateTime('20120922230000 [+9:JST]'), 
+            datetime(2012, 9, 22, 14, 0) )
 
 class TestParseStmtrs(TestCase):
     input = '''


### PR DESCRIPTION
Thank you for your great work. 
But I needed minor changes to parse OFX files provided by some Japanese institutions.

Changes:
- 'UTF-8' value for ENCODING header
- Plus sign in timezones. ex. '[+9:JST]'

I know that the OFX specification does not allow 'UTF-8' as a value of ENCODING header.
But, as long as I know, at least 4 well-known institutions, 2 banks and 2 credit card companies, provide OFX files with header 'ENCODING:UTF-8' as equivalent to 'ENCODING:UNICODE'.

I also added tests.
I think this change will help Japanese users.
