### PR TITLE
Fix close tags to help preserve document structural integrity

### DIFF
--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -4,6 +4,7 @@ import datetime
 import codecs
 import mcc
 import re
+import StringIO
 
 class OfxFile(object):
     def __init__(self, fh):
@@ -66,6 +67,40 @@ class OfxFile(object):
                 self.headers = uheaders
         # Reset the fh to the original position
         self.fh.seek(orig_pos)
+
+
+class OfxPreprocessedFile(OfxFile):
+    def __init__(self, fh):
+        super(OfxPreprocessedFile,self).__init__(fh)
+
+        if self.fh is None:
+            return
+
+        ofx_string = self.fh.read()
+
+        # find all closing tags as hints
+        closing_tags = [ t.upper() for t in re.findall(r'</([^>]+)>',ofx_string) ]
+
+        # close all tags that don't have closing tags and
+        # leave all other data intact
+        last_open_tag = None
+        tokens        = re.split('(<[^>]+>)', ofx_string)
+        new_fh        = StringIO.StringIO()
+        for idx,token in enumerate(tokens):
+            if token.startswith('</') or token.startswith('<?'):
+                if last_open_tag is not None:
+                    new_fh.write("</%s>" % last_open_tag)
+                    last_open_tag = None
+            elif token.startswith('<'):
+                if last_open_tag is not None:
+                    new_fh.write("</%s>" % last_open_tag)
+                    last_open_tag = None
+                tag = re.findall(r'<([^>]+)>',token)[0]
+                if tag.upper() not in closing_tags:
+                    last_open_tag = tag
+            new_fh.write(token)
+        new_fh.seek(0)
+        self.fh = new_fh
 
 
 class Ofx(object):
@@ -193,7 +228,7 @@ class OfxParser(object):
         ofx_obj = Ofx()
 
         # Store the headers
-        ofx_file = OfxFile(file_handle)
+        ofx_file = OfxPreprocessedFile(file_handle)
         ofx_obj.headers = ofx_file.headers
         ofx_obj.accounts = []
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -8,7 +8,118 @@ sys.path.append('..')
 
 from support import open_file
 from ofxparse import OfxParser, AccountType, Account, Statement, Transaction
-from ofxparse.ofxparse import OfxFile, OfxParserException
+from ofxparse.ofxparse import OfxFile, OfxPreprocessedFile, OfxParserException
+
+class TestOfxPreprocessedFile(TestCase):
+
+    def testPreprocess(self):
+        fh = StringIO("""OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:USASCII
+CHARSET:1252
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:NONE
+
+<OFX><DTASOF>1111<INVBAL><BALLIST><BAL><NAME>Net<DTASOF>2222</BAL><BAL><NAME>Gross<DTASOF>3333</BAL></BALLIST></INVBAL></OFX>
+""")
+        expect = """OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:USASCII
+CHARSET:1252
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:NONE
+
+<OFX><DTASOF>1111</DTASOF><INVBAL><BALLIST><BAL><NAME>Net</NAME><DTASOF>2222</DTASOF></BAL><BAL><NAME>Gross</NAME><DTASOF>3333</DTASOF></BAL></BALLIST></INVBAL></OFX>
+"""
+        ofx_file = OfxPreprocessedFile(fh)
+        data     = ofx_file.fh.read()
+        self.assertEqual(data,expect)
+
+    def testHeaders(self):
+        expect = {"OFXHEADER": u"100",
+                  "DATA": u"OFXSGML",
+                  "VERSION": u"102",
+                  "SECURITY": None,
+                  "ENCODING": u"USASCII",
+                  "CHARSET": u"1252",
+                  "COMPRESSION": None,
+                  "OLDFILEUID": None,
+                  "NEWFILEUID": None,
+                  }
+        ofx = OfxParser.parse(open_file('bank_medium.ofx'))
+        self.assertEquals(expect, ofx.headers)
+
+    def testUTF8(self):
+        fh = StringIO("""OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:UNICODE
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:NONE
+
+""")
+        ofx_file = OfxPreprocessedFile(fh)
+        headers = ofx_file.headers
+        data = ofx_file.fh.read()
+
+        self.assertTrue(type(data) is unicode)
+        for key, value in headers.iteritems():
+            self.assertTrue(type(key) is unicode)
+            self.assertTrue(type(value) is not str)
+
+    def testCP1252(self):
+        fh = StringIO("""OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:USASCII
+CHARSET: 1252
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:NONE
+""")
+        ofx_file = OfxPreprocessedFile(fh)
+        headers = ofx_file.headers
+        result = ofx_file.fh.read()
+
+        self.assertTrue(type(result) is unicode)
+        for key, value in headers.iteritems():
+            self.assertTrue(type(key) is unicode)
+            self.assertTrue(type(value) is not str)
+
+    def testUTF8Japanese(self):
+        fh = StringIO("""OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:UTF-8
+CHARSET:CSUNICODE
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:NONE
+""")
+        ofx_file = OfxPreprocessedFile(fh)
+        headers = ofx_file.headers
+        result = ofx_file.fh.read()
+
+        self.assertTrue(type(result) is unicode)
+        for key, value in headers.iteritems():
+            self.assertTrue(type(key) is unicode)
+            self.assertTrue(type(value) is not str)
+
+    def testBrokenLineEndings(self):
+        fh = StringIO("OFXHEADER:100\rDATA:OFXSGML\r")
+        ofx_file = OfxPreprocessedFile(fh)
+        self.assertEquals(len(ofx_file.headers.keys()), 2)
+
 
 
 class TestOfxFile(TestCase):


### PR DESCRIPTION
Take a look at my lengthy comment in the relevant commit. It better explains the problem I set out to solve.

TLDR? I close tags to give throw BeautifulSoup a bone so it does not destroy document structure =)
