### PR TITLE
Tolerate missing <TICKER> in securities list.

### DIFF
--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -462,7 +462,12 @@ class OfxParser(object):
             name_tag = secinfo_ofx.find('secname')
             ticker_tag = secinfo_ofx.find('ticker')
             memo_tag = secinfo_ofx.find('memo')
-            if uniqueid_tag and name_tag and ticker_tag:
+            if uniqueid_tag and name_tag:
+                try:
+                    ticker = ticker_tag.contents[0].strip()
+                except AttributeError:
+                    # ticker can be empty
+                    ticker = None
                 try:
                     memo = memo_tag.contents[0].strip()
                 except AttributeError:
@@ -471,7 +476,7 @@ class OfxParser(object):
                 securityList.append(
                     Security(uniqueid_tag.contents[0].strip(),
                              name_tag.contents[0].strip(),
-                             ticker_tag.contents[0].strip(),
+                             ticker,
                              memo))
         return securityList
 


### PR DESCRIPTION
Hi, this is a patch to handle OFX entries with no ticker declared.
Previously these securities would be dropped.
