### PR TITLE
Allow decimal values using a comma as separator instead of a dot

### DIFF
--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -514,10 +514,10 @@ class OfxParser(object):
             position.security = tag.contents[0].strip()
         tag = ofx.find('units')
         if (hasattr(tag, 'contents')):
-            position.units = decimal.Decimal(tag.contents[0].strip())
+            position.units = cls_.toDecimal(tag)
         tag = ofx.find('unitprice')
         if (hasattr(tag, 'contents')):
-            position.unit_price = decimal.Decimal(tag.contents[0].strip())
+            position.unit_price = cls_.toDecimal(tag)
         tag = ofx.find('dtpriceasof')
         if (hasattr(tag, 'contents')):
             try:
@@ -554,10 +554,10 @@ class OfxParser(object):
             transaction.security = tag.contents[0].strip()
         tag = ofx.find('units')
         if (hasattr(tag, 'contents')):
-            transaction.units = decimal.Decimal(tag.contents[0].strip())
+            transaction.units = cls_.toDecimal(tag)
         tag = ofx.find('unitprice')
         if (hasattr(tag, 'contents')):
-            transaction.unit_price = decimal.Decimal(tag.contents[0].strip())
+            transaction.unit_price = cls_.toDecimal(tag)
         return transaction
 
     @classmethod
@@ -686,8 +686,7 @@ class OfxParser(object):
             dtasof_tag = bal_tag.find('dtasof')
             if hasattr(balamt_tag, "contents"):
                 try:
-                    setattr(statement, bal_attr, decimal.Decimal(
-                        balamt_tag.contents[0].strip()))
+                    setattr(statement, bal_attr, cls_.toDecimal(balamt_tag))
                 except (IndexError, decimal.InvalidOperation):
                     ex = sys.exc_info()[1]
                     statement.warnings.append(
@@ -821,8 +820,7 @@ class OfxParser(object):
         amt_tag = txn_ofx.find('trnamt')
         if hasattr(amt_tag, "contents"):
             try:
-                transaction.amount = decimal.Decimal(
-                    amt_tag.contents[0].strip())
+                transaction.amount = cls_.toDecimal(amt_tag)
             except IndexError:
                 raise OfxParserException("Invalid Transaction Date")
             except decimal.InvalidOperation:
@@ -887,3 +885,10 @@ class OfxParser(object):
                 raise OfxParserException(six.u("Empty Check (or other reference) number"))
 
         return transaction
+
+    @classmethod
+    def toDecimal(cls_, tag):
+        d = tag.contents[0].strip()
+        if ',' in d:
+            d = d.replace(',', '.')
+        return decimal.Decimal(d)


### PR DESCRIPTION
French (and most likely other) banks can send values like "4405,95" (with a comma) for balance values instead of "4405.95" (with a dot).

The decimal.Decimal class constructor expects a string representation of decimal values using the dot as separator so values containing a comma raise a decimal.InvalidOperation error.

This pull request fixes this problem.

The toDecimal method can probably be written better (no test, no use of a temporary variable).