### PR TITLE
Support decimal comma for transaction amounts, #83

### DIFF
--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -901,8 +901,10 @@ class OfxParser(object):
         amt_tag = txn_ofx.find('trnamt')
         if hasattr(amt_tag, "contents"):
             try:
-                transaction.amount = decimal.Decimal(
-                    amt_tag.contents[0].strip())
+                contents = amt_tag.contents[0].strip()
+                if '.' not in contents:
+                    contents = contents.replace(',', '.')
+                transaction.amount = decimal.Decimal(contents)
             except IndexError:
                 raise OfxParserException("Invalid Transaction Date")
             except decimal.InvalidOperation:

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -442,6 +442,36 @@ class TestParseTransaction(TestCase):
         transaction = OfxParser.parseTransaction(txn.find('stmttrn'))
         self.assertEquals('700', transaction.checknum)
 
+    def testThatParseTransactionWithCommaAsDecimalPoint(self):
+        input = '''
+<STMTTRN>
+ <TRNTYPE>POS
+ <DTPOSTED>20090401122017.000[-5:EST]
+ <TRNAMT>-1006,60
+ <FITID>0000123456782009040100001
+ <NAME>MCDONALD'S #112
+ <MEMO>POS MERCHANDISE;MCDONALD'S #112
+</STMTTRN>
+'''
+        txn = soup_maker(input)
+        transaction = OfxParser.parseTransaction(txn.find('stmttrn'))
+        self.assertEquals(Decimal('-1006.60'), transaction.amount)
+
+    def testThatParseTransactionWithCommaAsDecimalPointAndDotAsSeparator(self):
+        input = '''
+<STMTTRN>
+ <TRNTYPE>POS
+ <DTPOSTED>20090401122017.000[-5:EST]
+ <TRNAMT>-1.006,60
+ <FITID>0000123456782009040100001
+ <NAME>MCDONALD'S #112
+ <MEMO>POS MERCHANDISE;MCDONALD'S #112
+</STMTTRN>
+'''
+        txn = soup_maker(input)
+        with self.assertRaises(OfxParserException):
+            transaction = OfxParser.parseTransaction(txn.find('stmttrn'))
+
 class TestTransaction(TestCase):
     def testThatAnEmptyTransactionIsValid(self):
         t = Transaction()


### PR DESCRIPTION
BNP Paribas Fortis in Belgium uses commas as the decimal separator instead of
points.