### PR TITLE
#87: Fix split futurewarning

### DIFF
--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -103,9 +103,7 @@ class OfxFile(object):
         head_data = self.fh.read(1024 * 10)
         head_data = head_data[:head_data.find(six.b('<'))]
 
-        normalised = head_data.replace(six.b('\r\n'), six.b('\n')).replace(six.b('\r'), six.b('\n'))
-
-        for line in re.split(six.b('\n'), normalised):
+        for line in head_data.splitlines():
             # Newline?
             if line.strip() == six.b(""):
                 break

--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -103,7 +103,9 @@ class OfxFile(object):
         head_data = self.fh.read(1024 * 10)
         head_data = head_data[:head_data.find(six.b('<'))]
 
-        for line in re.split(six.b('\r?\n?'), head_data):
+        normalised = head_data.replace(six.b('\r\n'), six.b('\n')).replace(six.b('\r'), six.b('\n'))
+
+        for line in re.split(six.b('\n'), normalised):
             # Newline?
             if line.strip() == six.b(""):
                 break


### PR DESCRIPTION
#87 Avoid using a regular expression with a possibly-empty match. Use the built-in 'splitlines' instead, which will cope with all naturally-occurring EOL patterns.