### PR TITLE
Fix README to work with Python 2 and 3.

### DIFF
--- a/README
+++ b/README
@@ -19,7 +19,7 @@ Here's a sample program::
 
   from ofxparse import OfxParser
 
-  ofx = OfxParser.parse(file('file.ofx'))
+  ofx = OfxParser.parse(open('file.ofx', 'rb'))
   ofx.accounts                        # An account with information
   ofx.account.number                  # The account number
   ofx.account.routing_number          # The transit id (sometimes called branch number)


### PR DESCRIPTION
Fix #79. Take dorfsmay's suggestion and apply it, now that 'file' is no
longer available in Python 3.