### PR TITLE
Support checking/savings accounts in Fidelity.

### DIFF
--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -714,6 +714,18 @@ class OfxParser(object):
                      six.u('content'): investment_ofx}
                 )
 
+        for transaction_ofx in invstmtrs_ofx.findAll('invbanktran'):
+            for stmt_ofx in transaction_ofx.findAll('stmttrn'):
+                try:
+                    statement.transactions.append(
+                        cls_.parseTransaction(stmt_ofx))
+                except OfxParserException:
+                    ofxError = sys.exc_info()[1]
+                    statement.discarded_entries.append(
+                        {'error': str(ofxError), 'content': transaction_ofx})
+                    if cls_.fail_fast:
+                        raise
+
         invbal_ofx = invstmtrs_ofx.find('invbal')
         if invbal_ofx is not None:
             #<AVAILCASH>18073.98<MARGINBALANCE>+00000000000.00<SHORTBALANCE>+00000000000.00<BUYPOWER>+00000000000.00

--- a/tests/fixtures/fidelity-savings.ofx
+++ b/tests/fixtures/fidelity-savings.ofx
@@ -1,0 +1,111 @@
+OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:USASCII
+CHARSET:1252
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0
+
+
+<OFX>
+  <SIGNONMSGSRSV1>
+    <SONRS>
+    <STATUS>
+    <CODE>0
+    <SEVERITY>INFO
+    <MESSAGE>SUCCESS
+    </STATUS>
+    <DTSERVER>20120908190849.317[-4:EDT]
+    <LANGUAGE>ENG
+    <FI>
+    <ORG>fidelity.com
+    <FID>7776
+    </FI>
+    </SONRS>
+  </SIGNONMSGSRSV1>
+  <INVSTMTMSGSRSV1>
+    <INVSTMTTRNRS>
+      <TRNUID>00000000000000000000000001
+      <STATUS>
+        <CODE>0
+        <SEVERITY>INFO
+        <MESSAGE>SUCCESS
+      </STATUS>
+      <INVSTMTRS>
+        <DTASOF>20120908190851.317[-4:EDT]
+        <CURDEF>USD
+        <INVACCTFROM>
+          <BROKERID>fidelity.com
+          <ACCTID>X0000001
+        </INVACCTFROM>
+        <INVTRANLIST>
+          <DTSTART>20120710000000.000[-4:EDT]
+          <DTEND>20120908190849.555[-4:EDT]
+          <INVBANKTRAN>    
+            <STMTTRN>
+              <TRNTYPE>CHECK
+              <DTPOSTED>20120720000000.000[-4:EDT]
+              <TRNAMT>-00000000001500.0000
+              <FITID>X0000000000000000000001
+              <CHECKNUM>0000001001
+              <NAME>Check Paid #0000001001
+              <MEMO>Check Paid #0000001001
+              <CURRENCY>
+                <CURRATE>1.00
+                <CURSYM>USD
+              </CURRENCY>
+            </STMTTRN>
+            <SUBACCTFUND>CASH    
+          </INVBANKTRAN>
+          <INVBANKTRAN>    
+            <STMTTRN>
+              <TRNTYPE>DEP
+              <DTPOSTED>20120727000000.000[-4:EDT]
+              <TRNAMT>+00000000000115.8331
+              <FITID>X0000000000000000000002
+              <NAME>TRANSFERRED FROM     VS X10-08144
+              <MEMO>TRANSFERRED FROM     VS X10-08144-1
+              <CURRENCY>
+                <CURRATE>1.00
+                <CURSYM>USD
+              </CURRENCY>
+            </STMTTRN>
+            <SUBACCTFUND>CASH    
+          </INVBANKTRAN>
+          <INVBANKTRAN>    
+            <STMTTRN>
+              <TRNTYPE>PAYMENT
+              <DTPOSTED>20120727000000.000[-4:EDT]
+              <TRNAMT>-00000000000197.1063
+              <FITID>X0000000000000000000003
+              <NAME>BILL PAYMENT         CITICORP CH
+              <MEMO>BILL PAYMENT         CITICORP CHOICE          /0001/N********
+              <CURRENCY>
+                <CURRATE>1.00
+                <CURSYM>USD
+              </CURRENCY>
+            </STMTTRN>
+            <SUBACCTFUND>CASH    
+          </INVBANKTRAN>
+          <INVBANKTRAN>    
+            <STMTTRN>
+              <TRNTYPE>CASH
+              <DTPOSTED>20120727000000.000[-4:EDT]
+              <TRNAMT>-00000000000197.1220
+              <FITID>X0000000000000000000004
+              <NAME>DIRECT               DEBIT HOMES
+              <MEMO>DIRECT               DEBIT HOMESTREET LS LOAN PMT
+              <CURRENCY>
+                <CURRATE>1.00
+                <CURSYM>USD
+              </CURRENCY>
+            </STMTTRN>
+            <SUBACCTFUND>CASH    
+          </INVBANKTRAN>
+        </INVTRANLIST>
+      </INVSTMTRS>
+    </INVSTMTTRNRS>
+  </INVSTMTMSGSRSV1>
+</OFX>

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -644,6 +644,31 @@ class TestFidelityInvestmentStatement(TestCase):
         self.assertEquals(ofx.account.statement.short_balance, Decimal('0'))
         self.assertEquals(ofx.account.statement.buy_power, Decimal('0'))
 
+class TestFidelitySavingsStatement(TestCase):
+    def testSTMTTRNInInvestmentBank(self):
+        ofx = OfxParser.parse(open_file('fidelity-savings.ofx'))
+
+        self.assertTrue(hasattr(ofx.account.statement, 'transactions'))
+        self.assertEquals(len(ofx.account.statement.transactions), 4)
+
+        tx = ofx.account.statement.transactions[0]
+        self.assertEquals('check', tx.type)
+        self.assertEquals(datetime(
+            2012, 7, 20, 0, 0, 0) - timedelta(hours=-4), tx.date)
+        self.assertEquals(Decimal('-1500.00'), tx.amount)
+        self.assertEquals('X0000000000000000000001', tx.id)
+        self.assertEquals('Check Paid #0000001001', tx.payee)
+        self.assertEquals('Check Paid #0000001001', tx.memo)
+
+        tx = ofx.account.statement.transactions[1]
+        self.assertEquals('dep', tx.type)
+        self.assertEquals(datetime(
+            2012, 7, 27, 0, 0, 0) - timedelta(hours=-4), tx.date)
+        self.assertEquals(Decimal('115.8331'), tx.amount)
+        self.assertEquals('X0000000000000000000002', tx.id)
+        self.assertEquals('TRANSFERRED FROM     VS X10-08144', tx.payee)
+        self.assertEquals('TRANSFERRED FROM     VS X10-08144-1', tx.memo)
+
 class Test401InvestmentStatement(TestCase):
     def testTransferAggregate(self):
         ofx = OfxParser.parse(open_file('investment_401k.ofx'))


### PR DESCRIPTION
Fidelity returns STMTTRN in INVSTMTRS/INVTRANLIST/INVBANKTRAN. OfxParser
supports only investment transactions within INVSTMTRS, so parsing
Fidelity OFX feed returns no transactions in this case.
