### PR TITLE
Make OfxPrinter compatible with Python 3

### DIFF
--- a/ofxparse/ofxprinter.py
+++ b/ofxparse/ofxprinter.py
@@ -1,3 +1,5 @@
+import six
+
 class OfxPrinter():
     ofx = None
     out_filename = None
@@ -24,7 +26,7 @@ class OfxPrinter():
         )
 
     def writeHeaders(self):
-        for k, v in self.ofx.headers.iteritems():
+        for k, v in six.iteritems(self.ofx.headers):
             if v is None:
                 self.writeLine("{0}:NONE".format(k))
             else:
@@ -183,7 +185,7 @@ class OfxPrinter():
         if filename is None:
             filename = self.out_filename
 
-        self.out_handle = open(filename, 'wb')
+        self.out_handle = open(filename, 'w')
 
         self.writeHeaders()
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
-from ofxparse import OfxParser as op
+from ofxparse import OfxParser as op, OfxPrinter
 from unittest import TestCase
+from os import close, remove
+from tempfile import mkstemp
 import sys
 sys.path.append('..')
 from .support import open_file
@@ -12,6 +14,14 @@ class TestOfxWrite(TestCase):
         test_file = open_file('fidelity.ofx')
         ofx_doc = op.parse(test_file)
         self.assertEqual(str(ofx_doc), "")
+
+    def test_using_ofx_printer(self):
+        test_file = open_file('checking.ofx')
+        ofx_doc = op.parse(test_file)
+        fd, name = mkstemp()
+        close(fd)
+        printer = OfxPrinter(ofx=ofx_doc, filename=name)
+        printer.write(tabs=1)
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
Should be still compatible with Python 2, but I don't have that installed to test on.
I also added a simple test just to make sure that it runs.