### PR TITLE
Support text file handler

### DIFF
--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -70,6 +70,12 @@ class OfxFile(object):
         if not hasattr(self.fh, "seek"):
             return  # fh is not a file object, we're doomed.
 
+        # If the file handler is text stream, convert to bytes one:
+        first = self.fh.read(1)
+        if type(first) != bytes:
+            self.fh = six.BytesIO(six.b(self.fh.read()))
+        self.fh.seek(0)
+
         with save_pos(self.fh):
             self.read_headers()
             self.handle_encoding()

--- a/tests/support.py
+++ b/tests/support.py
@@ -1,9 +1,9 @@
 import os
 
 
-def open_file(filename):
+def open_file(filename, mode='rb'):
     ''' Load a file from the fixtures directory. '''
     path = 'fixtures/' + filename
     if ('tests' in os.listdir('.')):
         path = 'tests/' + path
-    return open(path, mode='rb')
+    return open(path, mode=mode)

--- a/tests/support.py
+++ b/tests/support.py
@@ -2,8 +2,10 @@ import os
 
 
 def open_file(filename, mode='rb'):
-    ''' Load a file from the fixtures directory. '''
-    path = 'fixtures/' + filename
-    if ('tests' in os.listdir('.')):
-        path = 'tests/' + path
+    """
+    Load a file from the fixtures directory.
+    """
+    path = os.path.join('fixtures', filename)
+    if 'tests' in os.listdir('.'):
+        path = os.path.join('tests', path)
     return open(path, mode=mode)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -17,6 +17,16 @@ from ofxparse.ofxparse import OfxFile, OfxPreprocessedFile, OfxParserException, 
 class TestOfxFile(TestCase):
     OfxFileCls = OfxFile
 
+    def assertHeadersTypes(self, headers):
+        """
+        Assert that the headers keys and values have the correct types
+
+        :param headers: headers dict from a OfxFile or OfxPreprocessedFile instance
+        """
+        for key, value in six.iteritems(headers):
+            self.assertTrue(type(key) is six.text_type)
+            self.assertTrue(type(value) is not six.binary_type)
+
     def testHeaders(self):
         expect = {"OFXHEADER": six.u("100"),
                   "DATA": six.u("OFXSGML"),
@@ -40,18 +50,14 @@ class TestOfxFile(TestCase):
                 data = ofx_file.fh.read()
 
                 self.assertTrue(type(data) is six.text_type)
-                for key, value in six.iteritems(headers):
-                    self.assertTrue(type(key) is six.text_type)
-                    self.assertTrue(type(value) is not six.binary_type)
+                self.assertHeadersTypes(headers)
 
                 ofx_file = self.OfxFileCls(fh_str)
                 headers = ofx_file.headers
                 data = ofx_file.fh.read()
 
                 self.assertTrue(type(data) is six.text_type)
-                for key, value in six.iteritems(headers):
-                    self.assertTrue(type(key) is six.text_type)
-                    self.assertTrue(type(value) is not six.binary_type)
+                self.assertHeadersTypes(headers)
 
     def testUTF8(self):
         fh = six.BytesIO(six.b("""OFXHEADER:100
@@ -69,9 +75,7 @@ NEWFILEUID:NONE
         data = ofx_file.fh.read()
 
         self.assertTrue(type(data) is six.text_type)
-        for key, value in six.iteritems(headers):
-            self.assertTrue(type(key) is six.text_type)
-            self.assertTrue(type(value) is not six.binary_type)
+        self.assertHeadersTypes(headers)
 
     def testCP1252(self):
         fh = six.BytesIO(six.b("""OFXHEADER:100
@@ -89,9 +93,7 @@ NEWFILEUID:NONE
         result = ofx_file.fh.read()
 
         self.assertTrue(type(result) is six.text_type)
-        for key, value in six.iteritems(headers):
-            self.assertTrue(type(key) is six.text_type)
-            self.assertTrue(type(value) is not six.binary_type)
+        self.assertHeadersTypes(headers)
 
     def testUTF8Japanese(self):
         fh = six.BytesIO(six.b("""OFXHEADER:100
@@ -109,9 +111,7 @@ NEWFILEUID:NONE
         result = ofx_file.fh.read()
 
         self.assertTrue(type(result) is six.text_type)
-        for key, value in six.iteritems(headers):
-            self.assertTrue(type(key) is six.text_type)
-            self.assertTrue(type(value) is not six.binary_type)
+        self.assertHeadersTypes(headers)
 
     def testBrokenLineEndings(self):
         fh = six.BytesIO(six.b("OFXHEADER:100\rDATA:OFXSGML\r"))

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -142,6 +142,27 @@ class TestOfxFile(TestCase):
             ofx = OfxParser.parse(f)
         self.assertEqual(expect, ofx.headers)
 
+    def testTextFileHandler(self):
+        with open_file("bank_medium.ofx") as fh:
+            with open_file("bank_medium.ofx", mode="r") as fh_str:
+                ofx_file = OfxFile(fh)
+                headers = ofx_file.headers
+                data = ofx_file.fh.read()
+
+                self.assertTrue(type(data) is six.text_type)
+                for key, value in six.iteritems(headers):
+                    self.assertTrue(type(key) is six.text_type)
+                    self.assertTrue(type(value) is not six.binary_type)
+
+                ofx_file = OfxFile(fh_str)
+                headers = ofx_file.headers
+                data = ofx_file.fh.read()
+
+                self.assertTrue(type(data) is six.text_type)
+                for key, value in six.iteritems(headers):
+                    self.assertTrue(type(key) is six.text_type)
+                    self.assertTrue(type(value) is not six.binary_type)
+
     def testUTF8(self):
         fh = six.BytesIO(six.b("""OFXHEADER:100
 DATA:OFXSGML


### PR DESCRIPTION
If I pass a file opened in text mode (mode='r' as oppose to mode='rb'), OfxParser.parse fails, in Python 3 (3.5, to be more exact) because it ends up trying to mix bytes and str when reading the headers, [here](https://github.com/jseutter/ofxparse/blob/master/ofxparse/ofxparse.py#L80). Even after fixing it, though, it still fails in OfxPreprocessedFile, when it tries to read from self.fh. It happens because self.fh, at that point, is a codecs.StreamReader, which will only work with bytes streams (again, at least on Python 3). This pull request fixes this, at least in Python 3.5 and 2.7.