### PR TITLE
Move import to top level.

### DIFF
--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -22,13 +22,12 @@ else:
 
 from . import mcc
 
-def soup_maker(fh):
-    try:
-        from bs4 import BeautifulSoup
-        return BeautifulSoup(fh, 'html.parser')
-    except ImportError:
-        from BeautifulSoup import BeautifulStoneSoup
-        return BeautifulStoneSoup(fh)
+try:
+    from bs4 import BeautifulSoup
+    soup_maker = lambda fh: BeautifulSoup(fh, 'html.parser')
+except ImportError:
+    from BeautifulSoup import BeautifulStoneSoup
+    soup_maker = BeautifulStoneSoup
 
 
 def try_decode(string, encoding):


### PR DESCRIPTION
I have been seeing import errors that I'm pretty sure are being caused
by soup_maker being called from multiple threads at once. I have not
been able to put together a minimal test case showing that this import
is indeed the issue, but regardless, it is better to make the import call
once at module load instead of each time parse() is called.