### PR TITLE
Generic ofx2dataframe converter capable of handling multiple inputs

### DIFF
--- a/ofxparse/ofxtodataframe.py
+++ b/ofxparse/ofxtodataframe.py
@@ -1,0 +1,44 @@
+from ofxparse import OfxParser
+import pandas as pd
+import codecs
+import os.path as path
+
+# fields of transactions are auto extracted using dir(transactiontype)-{attributes starting with '_'}
+
+def ofx_to_dataframe(files, id_len=24):
+    collected_df={}
+    if type(files) is str:
+        files = [files]
+    assert(isinstance(files, list))
+    for fname in files:
+        data = {}
+        with codecs.open(fname) as fileobj:
+            ofx = OfxParser.parse(fileobj)
+        # it seems one ofx file contains only one securities list. Create a mapping from ID to ticker
+        security_map = {x.uniqueid : x.ticker for x in ofx.security_list}
+        # different transaction types have different fields. So we create df for each txn_type
+        # and append the contents of each txn into appropriate df
+        for account in ofx.accounts:
+            for transaction in account.statement.transactions:
+                txn_type = type(transaction).__name__
+                if not txn_type in data:
+                    fields = [x for x in dir(transaction) if not x.startswith('_')]
+                    data[txn_type] = pd.DataFrame(columns=fields)
+                df = data[txn_type]
+                fields = set(df.columns)
+                sr = pd.Series([getattr(transaction,f) for f in fields], index=fields)
+                data[txn_type] = df.append(sr, ignore_index=True)
+        # add fname, acctnum common info into each df. Truncate ID if needed
+        for key,df in data.items():
+            df['fname'] = path.basename(fname)
+            df['id'] = df['id'].str[:id_len]  # clip the last part of the ID which changes from download to download
+            df['acctnum']=account.number
+            if 'security' in df.columns:
+                df['security'] = df['security'].apply(lambda x: security_map[x])
+            if 'AGGREGATE_TYPES' in df.columns :
+                del df['AGGREGATE_TYPES']
+            if key in collected_df:
+                collected_df[key] = collected_df[key].append(df, ignore_index=True)
+            else:
+                collected_df[key] = df
+    return collected_df

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -12,7 +12,8 @@ import six
 from .support import open_file
 from ofxparse import OfxParser, AccountType, Account, Statement, Transaction
 from ofxparse.ofxparse import OfxFile, OfxPreprocessedFile, OfxParserException, soup_maker
-
+from ofxparse.ofxtodataframe import ofx_to_dataframe
+import glob
 
 class TestOfxFile(TestCase):
     OfxFileCls = OfxFile
@@ -1006,6 +1007,20 @@ class TestParseSonrs(TestCase):
         self.assertEqual(ofx.signon.code, 15500)
         self.assertEqual(ofx.signon.severity, 'ERROR')
         self.assertEqual(ofx.signon.message, 'Your request could not be processed because you supplied an invalid identification code or your password was incorrect')
+
+class TestOfxToDataFrame(TestCase):
+    def testSingleFile(self):
+        dfs = ofx_to_dataframe('tests/fixtures/fidelity.ofx')
+        self.assertEqual(sorted(dfs), ['InvestmentTransaction', 'Transaction'])
+        self.assertEqual(len(dfs['InvestmentTransaction']), 14)
+        self.assertEqual(len(dfs['Transaction']), 3)
+
+    def testMultipleFiles(self):
+        dfs = ofx_to_dataframe(['tests/fixtures/fidelity.ofx', 'tests/fixtures/investment_401k.ofx'])
+        self.assertEqual(sorted(dfs), ['InvestmentTransaction', 'Transaction'])
+        self.assertEqual(len(dfs['InvestmentTransaction']), 17)
+        self.assertEqual(len(dfs['Transaction']), 3)
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
Hi. I find it useful to generate dataframe(s) from ofx transactions parsed from one or more ofx source files, for example when importing transactions into a personal finance app like beancount. Inspired by the code in utils/ofx2xlsx.py, I felt it would be better to make it generic to handle any available fields based on the transaction type and code the converter as a function returning mutiple dataframes (one per transaction type) accumulating transactions from all source files. The ofx2xlsx script then trivially has to convert the dataframes to csv or xlsx based on command line option 

Created unittest for the same.
Modified utils/ofx2xlsx.py script to use the converter and support
output in csv or xlsx format