### PR TITLE
Include "message" in ofx.status if it exists.

### DIFF
--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -411,6 +411,9 @@ class OfxParser(object):
                 )
                 ofx_obj.status['severity'] = \
                     stmttrnrs_status.find('severity').contents[0].strip()
+                message = stmttrnrs_status.find('message')
+                ofx_obj.status['message'] = \
+                    message.contents[0].strip() if message else None
 
         ccstmttrnrs = ofx.find('ccstmttrnrs')
         if ccstmttrnrs:
@@ -426,6 +429,9 @@ class OfxParser(object):
                 )
                 ofx_obj.status['severity'] = \
                     ccstmttrnrs_status.find('severity').contents[0].strip()
+                message = ccstmttrnrs_status.find('message')
+                ofx_obj.status['message'] = \
+                    message.contents[0].strip() if message else None
 
         stmtrs_ofx = ofx.findAll('stmtrs')
         if stmtrs_ofx:

--- a/tests/fixtures/error_message.ofx
+++ b/tests/fixtures/error_message.ofx
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?OFX OFXHEADER="200" VERSION="211" SECURITY="NONE" OLDFILEUID="NONE" NEWFILEUID="NONE"?>
+<OFX>
+    <SIGNONMSGSRSV1>
+        <SONRS>
+            <STATUS>
+                <CODE>0</CODE>
+                <SEVERITY>INFO</SEVERITY>
+                <MESSAGE>SUCCESS</MESSAGE>
+            </STATUS>
+            <DTSERVER>20180521052952.749[-7:PDT]</DTSERVER>
+            <LANGUAGE>ENG</LANGUAGE>
+            <FI>
+                <ORG>svb.com</ORG>
+                <FID>944</FID>
+            </FI>
+        </SONRS>
+    </SIGNONMSGSRSV1>
+    <BANKMSGSRSV1>
+        <STMTTRNRS>
+            <TRNUID>ae91f50f-f16d-4bc1-b88f-2a7fa04b6de1</TRNUID>
+            <STATUS>
+                <CODE>2000</CODE>
+                <SEVERITY>ERROR</SEVERITY>
+                <MESSAGE>General Server Error</MESSAGE>
+            </STATUS>
+        </STMTTRNRS>
+    </BANKMSGSRSV1>
+</OFX>

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -981,6 +981,14 @@ class TestGracefulFailures(TestCase):
         with open_file('fail_nice/empty_balance.ofx') as f:
             self.assertRaises(OfxParserException, OfxParser.parse, f)
 
+    def testErrorInTransactionList(self):
+        """There is an error in the transaction list."""
+        with open_file('error_message.ofx') as f:
+            ofx = OfxParser.parse(f, False)
+        self.assertEqual(ofx.status['code'], 2000)
+        self.assertEqual(ofx.status['severity'], 'ERROR')
+        self.assertEqual(ofx.status['message'], 'General Server Error')
+
 
 class TestParseSonrs(TestCase):
 


### PR DESCRIPTION
I noticed that we stuff `<CODE>` and `<SEVERITY>` from the `<STATUS>` aggregate but not the `<MESSAGE>`.  This adds it. 