### PR TITLE
Add user_date to the transaction object from the DTUSER field.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,7 @@ Here's a sample program
     transaction.payee
     transaction.type
     transaction.date
+    transaction.user_date
     transaction.amount
     transaction.id
     transaction.memo

--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -304,6 +304,7 @@ class Transaction(object):
         self.payee = ''
         self.type = ''
         self.date = None
+        self.user_date = None
         self.amount = None
         self.id = ''
         self.memo = ''
@@ -1024,6 +1025,19 @@ class OfxParser(object):
         else:
             raise OfxParserException(
                 six.u("Missing Transaction Date (a required field)"))
+
+        user_date_tag = txn_ofx.find('dtuser')
+        if hasattr(user_date_tag, "contents"):
+            try:
+                transaction.user_date = cls.parseOfxDateTime(
+                    user_date_tag.contents[0].strip())
+            except IndexError:
+                raise OfxParserException("Invalid Transaction User Date")
+            except ValueError:
+                ve = sys.exc_info()[1]
+                raise OfxParserException(str(ve))
+            except TypeError:
+                pass
 
         id_tag = txn_ofx.find('fitid')
         if hasattr(id_tag, "contents"):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -415,6 +415,7 @@ class TestParseTransaction(TestCase):
         input = '''
 <STMTTRN>
  <TRNTYPE>POS
+ <DTUSER>20090131
  <DTPOSTED>20090401122017.000[-5:EST]
  <TRNAMT>-6.60
  <FITID>0000123456782009040100001
@@ -427,6 +428,7 @@ class TestParseTransaction(TestCase):
         self.assertEqual('pos', transaction.type)
         self.assertEqual(datetime(
             2009, 4, 1, 12, 20, 17) - timedelta(hours=-5), transaction.date)
+        self.assertEqual(datetime(2009, 1, 31, 0, 0), transaction.user_date)
         self.assertEqual(Decimal('-6.60'), transaction.amount)
         self.assertEqual('0000123456782009040100001', transaction.id)
         self.assertEqual("MCDONALD'S #112", transaction.payee)


### PR DESCRIPTION
In a transaction dtuser reflects the date at which the transaction is
actually done. dtposted (the current date property of the transaction
object) reflects the date at which the transaction is effective.

This patch adds the dtuser to the transaction object as user_date.

Closes: #150