### PR TITLE
Add Support for iso-8859-1 (latin-1) as encoding when described as US…

### DIFF
--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -117,7 +117,10 @@ class OfxFile(object):
 
         if enc_type == "USASCII":
             cp = ascii_headers.get("CHARSET", "1252")
-            encoding = "cp%s" % (cp, )
+            if cp == "8859-1":
+                encoding = "iso-8859-1"
+            else:
+                encoding = "cp%s" % (cp, )
 
         elif enc_type in ("UNICODE", "UTF-8"):
             encoding = "utf-8"


### PR DESCRIPTION
Fixes issues when the header of the file look like this:

    OFXHEADER:100
    DATA:OFXSGML
    VERSION:102
    SECURITY:TYPE1
    ENCODING:USASCII
    CHARSET:8859-1
    COMPRESSION:NONE
    OLDFILEUID:NONE
    NEWFILEUID:NONE