### PR TITLE
Allow parsing OFX files starting with empty lines

### DIFF
--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -90,7 +90,7 @@ class OfxFile(object):
         for line in head_data.splitlines():
             # Newline?
             if line.strip() == six.b(""):
-                break
+                continue
 
             header, value = line.split(six.b(":"))
             header, value = header.strip().upper(), value.strip()


### PR DESCRIPTION
My bank OFX files start with empty lines, this PR fixes parsing of those files.