### PR TITLE
Handle `chknum` in transaction field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
 - '2.7'
-- '3.4'
 - '3.5'
 - '3.6'
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - '2.7'
 - '3.5'
 - '3.6'
+- '3.7'
 install:
 - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install BeautifulSoup six nose coverage
   python-coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 - '3.5'
 - '3.6'
 - '3.7'
+- '3.8'
 install:
 - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install BeautifulSoup six nose coverage
   python-coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ after_success:
 - coveralls
 deploy:
   provider: pypi
+  edge: true
   user: jseutter
   password:
     secure: buE5iS5WhggpFcqR7iIEfcnDNHGeZ4zcYlgy3p9mJKEP8s7NMVeYJc+0FnnNs2fOEVR1QUX/URFtAZegtW9Bi/hVSc2bECZxM75uH342vqtea2rNJ7wQLSugUO+w9Q7HvC2KqeVl3s5Qa4Y3+mwv3Ej4tPI/WfASaNZG3XkwX4c=

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ deploy:
     tags: true
     distributions: sdist bdist_wheel
     repo: jseutter/ofxparse
+    skip_existing: true

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,7 @@ Here's a sample program
     transaction.payee
     transaction.type
     transaction.date
+    transaction.user_date
     transaction.amount
     transaction.id
     transaction.memo

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Here's a sample program
 
   # Account
   
-  account = ofx.occount 
+  account = ofx.account 
   account.account_id        # The account number
   account.number            # The account number (deprecated -- returns account_id)
   account.routing_number    # The bank routing number

--- a/ofxparse/__init__.py
+++ b/ofxparse/__init__.py
@@ -4,7 +4,7 @@ from .ofxparse import (OfxParser, OfxParserException, AccountType, Account,
                        Statement, Transaction)
 from .ofxprinter import OfxPrinter
 
-__version__ = '0.19'
+__version__ = '0.20'
 __all__ = [
     'OfxParser',
     'OfxParserException',

--- a/ofxparse/__init__.py
+++ b/ofxparse/__init__.py
@@ -4,7 +4,7 @@ from .ofxparse import (OfxParser, OfxParserException, AccountType, Account,
                        Statement, Transaction)
 from .ofxprinter import OfxPrinter
 
-__version__ = '0.18'
+__version__ = '0.19'
 __all__ = [
     'OfxParser',
     'OfxParserException',

--- a/ofxparse/__init__.py
+++ b/ofxparse/__init__.py
@@ -4,7 +4,7 @@ from .ofxparse import (OfxParser, OfxParserException, AccountType, Account,
                        Statement, Transaction)
 from .ofxprinter import OfxPrinter
 
-__version__ = '0.20'
+__version__ = '0.21'
 __all__ = [
     'OfxParser',
     'OfxParserException',

--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -117,7 +117,10 @@ class OfxFile(object):
 
         if enc_type == "USASCII":
             cp = ascii_headers.get("CHARSET", "1252")
-            encoding = "cp%s" % (cp, )
+            if cp == "8859-1":
+                encoding = "iso-8859-1"
+            else:
+                encoding = "cp%s" % (cp, )
 
         elif enc_type in ("UNICODE", "UTF-8"):
             encoding = "utf-8"

--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -411,6 +411,9 @@ class OfxParser(object):
                 )
                 ofx_obj.status['severity'] = \
                     stmttrnrs_status.find('severity').contents[0].strip()
+                message = stmttrnrs_status.find('message')
+                ofx_obj.status['message'] = \
+                    message.contents[0].strip() if message else None
 
         ccstmttrnrs = ofx.find('ccstmttrnrs')
         if ccstmttrnrs:
@@ -426,6 +429,9 @@ class OfxParser(object):
                 )
                 ofx_obj.status['severity'] = \
                     ccstmttrnrs_status.find('severity').contents[0].strip()
+                message = ccstmttrnrs_status.find('message')
+                ofx_obj.status['message'] = \
+                    message.contents[0].strip() if message else None
 
         stmtrs_ofx = ofx.findAll('stmtrs')
         if stmtrs_ofx:

--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -13,6 +13,11 @@ try:
 except ImportError:
     from io import StringIO
 
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+
 import six
 from . import mcc
 
@@ -37,7 +42,7 @@ def try_decode(string, encoding):
 def is_iterable(candidate):
     if sys.version_info < (2, 6):
         return hasattr(candidate, 'next')
-    return isinstance(candidate, collections.Iterable)
+    return isinstance(candidate, Iterable)
 
 
 @contextlib.contextmanager

--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -1087,4 +1087,8 @@ class OfxParser(object):
         # Handle 10000,50 formatted numbers
         if '.' not in d and ',' in d:
             d = d.replace(',', '.')
+        # Handle 1 025,53 formatted numbers
+        d = d.replace(' ', '')
+        # Handle +1058,53 formatted numbers
+        d = d.replace('+', '')
         return decimal.Decimal(d)

--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -312,6 +312,7 @@ class Transaction(object):
         self.payee = ''
         self.type = ''
         self.date = None
+        self.user_date = None
         self.amount = None
         self.id = ''
         self.memo = ''
@@ -1032,6 +1033,19 @@ class OfxParser(object):
         else:
             raise OfxParserException(
                 six.u("Missing Transaction Date (a required field)"))
+
+        user_date_tag = txn_ofx.find('dtuser')
+        if hasattr(user_date_tag, "contents"):
+            try:
+                transaction.user_date = cls.parseOfxDateTime(
+                    user_date_tag.contents[0].strip())
+            except IndexError:
+                raise OfxParserException("Invalid Transaction User Date")
+            except ValueError:
+                ve = sys.exc_info()[1]
+                raise OfxParserException(str(ve))
+            except TypeError:
+                pass
 
         id_tag = txn_ofx.find('fitid')
         if hasattr(id_tag, "contents"):

--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -1079,13 +1079,14 @@ class OfxParser(object):
                 if cls.fail_fast:
                     raise
 
-        checknum_tag = txn_ofx.find('checknum')
-        if hasattr(checknum_tag, 'contents'):
-            try:
-                transaction.checknum = checknum_tag.contents[0].strip()
-            except IndexError:
-                raise OfxParserException(six.u("Empty Check (or other reference) \
-                    number"))
+        for check_field in ('checknum', 'chknum'):
+            checknum_tag = txn_ofx.find(check_field)
+            if hasattr(checknum_tag, 'contents'):
+                try:
+                    transaction.checknum = checknum_tag.contents[0].strip()
+                except IndexError:
+                    raise OfxParserException(six.u("Empty Check (or other reference) \
+                        number"))
 
         return transaction
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 python-coveralls
+beautifulsoup4

--- a/tests/fixtures/error_message.ofx
+++ b/tests/fixtures/error_message.ofx
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?OFX OFXHEADER="200" VERSION="211" SECURITY="NONE" OLDFILEUID="NONE" NEWFILEUID="NONE"?>
+<OFX>
+    <SIGNONMSGSRSV1>
+        <SONRS>
+            <STATUS>
+                <CODE>0</CODE>
+                <SEVERITY>INFO</SEVERITY>
+                <MESSAGE>SUCCESS</MESSAGE>
+            </STATUS>
+            <DTSERVER>20180521052952.749[-7:PDT]</DTSERVER>
+            <LANGUAGE>ENG</LANGUAGE>
+            <FI>
+                <ORG>svb.com</ORG>
+                <FID>944</FID>
+            </FI>
+        </SONRS>
+    </SIGNONMSGSRSV1>
+    <BANKMSGSRSV1>
+        <STMTTRNRS>
+            <TRNUID>ae91f50f-f16d-4bc1-b88f-2a7fa04b6de1</TRNUID>
+            <STATUS>
+                <CODE>2000</CODE>
+                <SEVERITY>ERROR</SEVERITY>
+                <MESSAGE>General Server Error</MESSAGE>
+            </STATUS>
+        </STMTTRNRS>
+    </BANKMSGSRSV1>
+</OFX>

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -449,6 +449,20 @@ class TestParseTransaction(TestCase):
         transaction = OfxParser.parseTransaction(txn.find('stmttrn'))
         self.assertEqual('700', transaction.checknum)
 
+    def testThatParseTransactionWithFieldChkNum(self):
+        input = '''
+<STMTTRN>
+    <TRNTYPE>CHECK
+    <DTPOSTED>20231121
+    <TRNAMT>-113.71
+    <FITID>0000489
+    <CHKNUM>1932
+</STMTTRN>
+'''
+        txn = soup_maker(input)
+        transaction = OfxParser.parseTransaction(txn.find('stmttrn'))
+        self.assertEqual('1932', transaction.checknum)
+
     def testThatParseTransactionWithCommaAsDecimalPoint(self):
         input = '''
 <STMTTRN>

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -981,6 +981,14 @@ class TestGracefulFailures(TestCase):
         with open_file('fail_nice/empty_balance.ofx') as f:
             self.assertRaises(OfxParserException, OfxParser.parse, f)
 
+    def testErrorInTransactionList(self):
+        """There is an error in the transaction list."""
+        with open_file('error_message.ofx') as f:
+            ofx = OfxParser.parse(f, False)
+        self.assertEqual(ofx.status['code'], 2000)
+        self.assertEqual(ofx.status['severity'], 'ERROR')
+        self.assertEqual(ofx.status['message'], 'General Server Error')
+
 
 class TestParseSonrs(TestCase):
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -852,7 +852,7 @@ class TestTDAmeritrade(TestCase):
         account = ofx.accounts[0]
         statement = account.statement
         positions = statement.positions
-        self.assertEquals(len(positions), 2)
+        self.assertEqual(len(positions), 2)
 
         expected_positions = [
             {

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -493,6 +493,38 @@ class TestParseTransaction(TestCase):
         transaction = OfxParser.parseTransaction(txn.find('stmttrn'))
         self.assertEqual(Decimal('-1006.60'), transaction.amount)
 
+    def testThatParseTransactionWithLeadingPlusSign(self):
+        " Parse numbers with a leading '+' sign. "
+        input = '''
+<STMTTRN>
+ <TRNTYPE>POS
+ <DTPOSTED>20090401122017.000[-5:EST]
+ <TRNAMT>+1,006.60
+ <FITID>0000123456782009040100001
+ <NAME>MCDONALD'S #112
+ <MEMO>POS MERCHANDISE;MCDONALD'S #112
+</STMTTRN>
+'''
+        txn = soup_maker(input)
+        transaction = OfxParser.parseTransaction(txn.find('stmttrn'))
+        self.assertEqual(Decimal('1006.60'), transaction.amount)
+
+    def testThatParseTransactionWithSpaces(self):
+        " Parse numbers with a space separating the thousands. "
+        input = '''
+<STMTTRN>
+ <TRNTYPE>POS
+ <DTPOSTED>20090401122017.000[-5:EST]
+ <TRNAMT>+1 006,60
+ <FITID>0000123456782009040100001
+ <NAME>MCDONALD'S #112
+ <MEMO>POS MERCHANDISE;MCDONALD'S #112
+</STMTTRN>
+'''
+        txn = soup_maker(input)
+        transaction = OfxParser.parseTransaction(txn.find('stmttrn'))
+        self.assertEqual(Decimal('1006.60'), transaction.amount)
+
     def testThatParseTransactionWithNullAmountIgnored(self):
         """A null transaction value is converted to 0.
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -415,6 +415,7 @@ class TestParseTransaction(TestCase):
         input = '''
 <STMTTRN>
  <TRNTYPE>POS
+ <DTUSER>20090131
  <DTPOSTED>20090401122017.000[-5:EST]
  <TRNAMT>-6.60
  <FITID>0000123456782009040100001
@@ -427,6 +428,7 @@ class TestParseTransaction(TestCase):
         self.assertEqual('pos', transaction.type)
         self.assertEqual(datetime(
             2009, 4, 1, 12, 20, 17) - timedelta(hours=-5), transaction.date)
+        self.assertEqual(datetime(2009, 1, 31, 0, 0), transaction.user_date)
         self.assertEqual(Decimal('-6.60'), transaction.amount)
         self.assertEqual('0000123456782009040100001', transaction.id)
         self.assertEqual("MCDONALD'S #112", transaction.payee)


### PR DESCRIPTION
Hi.

This PR adds the support of the `chknum` field in a transaction.
It's the same than `checknum`, I don't know why there are two names for the same thing.
I added a test with that field, all other tests are still ok `Ran 68 tests in 0.282s`.

I don't think one ofx file can have both fields, that's why I reused the `transaction.checknum` attribute.