### PR TITLE
Add writer of Credit Card Statement

### DIFF
--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -259,6 +259,9 @@ class Signon:
         else:
             self.success = False
 
+        self.dtserver = OfxParser.parseOfxDateTime(
+            self.dtserver.strip())
+
     def __str__(self):
         ret = "\t<SIGNONMSGSRSV1>\r\n" + "\t\t<SONRS>\r\n" + \
               "\t\t\t<STATUS>\r\n"

--- a/ofxparse/ofxprinter.py
+++ b/ofxparse/ofxprinter.py
@@ -7,16 +7,19 @@ class OfxPrinter():
     out_handle = None
     term = "\r\n"
 
-    def __init__(self, ofx, filename, term="\r\n"):
+    def __init__(self, ofx, filename, term="\r\n", tabs=True):
         self.ofx = ofx
         self.out_filename = filename
         self.term = term
+        self.tabs_enabled = tabs
 
     def writeLine(self, data, tabs=0, term=None):
         if term is None:
             term = self.term
 
-        tabbing = (tabs * "\t") if (tabs > 0) else ''
+        tabbing = ''
+        if self.tabs_enabled:
+            tabbing = (tabs * "\t") if (tabs > 0) else ''
 
         return self.out_handle.write(
             "{0}{1}{2}".format(

--- a/ofxparse/ofxprinter.py
+++ b/ofxparse/ofxprinter.py
@@ -93,7 +93,8 @@ class OfxPrinter():
                 trn.checknum
             ), tabs=tabs)
 
-        self.writeLine("<NAME>{}".format(trn.payee), tabs=tabs)
+        if len(trn.payee) > 0:
+            self.writeLine("<NAME>{}".format(trn.payee), tabs=tabs)
 
         if len(trn.memo.strip()) > 0:
             self.writeLine("<MEMO>{}".format(trn.memo), tabs=tabs)

--- a/ofxparse/ofxprinter.py
+++ b/ofxparse/ofxprinter.py
@@ -264,7 +264,10 @@ class OfxPrinter():
         self.writeLine("<OFX>", tabs=tabs)
         tabs += 1
         self.writeSignOn(tabs=tabs)
-        self.writeBankMsgsRsv1(tabs=tabs)
+        if self.ofx.account.type == 2:
+            self.writeCreditCardMsgsRsv1(tabs=tabs)
+        else:
+            self.writeBankMsgsRsv1(tabs=tabs)
         tabs -= 1
         # No newline at end of file
         self.writeLine("</OFX>", tabs=tabs, term="")

--- a/ofxparse/ofxprinter.py
+++ b/ofxparse/ofxprinter.py
@@ -174,6 +174,44 @@ class OfxPrinter():
 
             self.writeLine("</STMTRS>", tabs=tabs)
 
+    def writeCCStmTrs(self, tabs=3):
+        for acct in self.ofx.accounts:
+            self.writeLine("<CCSTMTRS>", tabs=tabs)
+            tabs += 1
+
+            if acct.curdef:
+                self.writeLine("<CURDEF>{0}".format(
+                    acct.curdef
+                ), tabs=tabs)
+
+            if acct.account_id:
+                self.writeLine("<CCACCTFROM>", tabs=tabs)
+                self.writeLine("<ACCTID>{0}".format(
+                    acct.account_id
+                ), tabs=tabs+1)
+                self.writeLine("</CCACCTFROM>", tabs=tabs)
+
+            self.writeLine("<BANKTRANLIST>", tabs=tabs)
+            tabs += 1
+            self.writeLine("<DTSTART>{0}".format(
+                self.printDate(acct.statement.start_date)
+            ), tabs=tabs)
+            self.writeLine("<DTEND>{0}".format(
+                self.printDate(acct.statement.end_date)
+            ), tabs=tabs)
+
+            for trn in acct.statement.transactions:
+                self.writeTrn(trn, tabs=tabs)
+
+            tabs -= 1
+
+            self.writeLine("</BANKTRANLIST>", tabs=tabs)
+            self.writeLedgerBal(acct.statement, tabs=tabs)
+
+            tabs -= 1
+
+            self.writeLine("</CCSTMTRS>", tabs=tabs)
+
     def writeBankMsgsRsv1(self, tabs=1):
         self.writeLine("<BANKMSGSRSV1>", tabs=tabs)
         tabs += 1

--- a/ofxparse/ofxprinter.py
+++ b/ofxparse/ofxprinter.py
@@ -38,9 +38,34 @@ class OfxPrinter():
         self.writeLine("")
 
     def writeSignOn(self, tabs=0):
-        # signon already has newlines and tabs in it
-        # TODO: reimplement signon printing with tabs
-        self.writeLine(self.ofx.signon.__str__(), term="")
+        if self.ofx.signon:
+            self.writeLine("<SIGNONMSGSRSV1>", tabs=tabs)
+            tabs += 1
+            self.writeLine("<SONRS>", tabs=tabs)
+            tabs += 1
+            if self.ofx.signon.code or self.ofx.signon.severity:
+                self.writeLine("<STATUS>", tabs=tabs)
+                if self.ofx.signon.code is not None:
+                    self.writeLine("<CODE>{0}".format(
+                        self.ofx.signon.code
+                    ), tabs=tabs + 1)
+                if self.ofx.signon.severity:
+                    self.writeLine("<SEVERITY>{0}".format(
+                        self.ofx.signon.severity
+                    ), tabs=tabs + 1)
+                self.writeLine("</STATUS>", tabs=tabs)
+            if self.ofx.signon.dtserver:
+                self.writeLine("<DTSERVER>{0}".format(
+                    self.printDate(self.ofx.signon.dtserver)
+                ), tabs=tabs)
+            if self.ofx.signon.language:
+                self.writeLine("<LANGUAGE>{0}".format(
+                    self.ofx.signon.language
+                ), tabs=tabs)
+            tabs -= 1
+            self.writeLine("</SONRS>", tabs=tabs)
+            tabs -= 1
+            self.writeLine("</SIGNONMSGSRSV1>", tabs=tabs)
 
     def printDate(self, dt, msec_digs=3):
         strdt = dt.strftime('%Y%m%d%H%M%S')

--- a/ofxparse/ofxprinter.py
+++ b/ofxparse/ofxprinter.py
@@ -236,6 +236,30 @@ class OfxPrinter():
         tabs -= 1
         self.writeLine("</BANKMSGSRSV1>", tabs=tabs)
 
+    def writeCreditCardMsgsRsv1(self, tabs=1):
+        self.writeLine("<CREDITCARDMSGSRSV1>", tabs=tabs)
+        tabs += 1
+        self.writeLine("<CCSTMTTRNRS>", tabs=tabs)
+        tabs += 1
+        if self.ofx.trnuid is not None:
+            self.writeLine("<TRNUID>{0}".format(
+                self.ofx.trnuid
+            ), tabs=tabs)
+        if self.ofx.status:
+            self.writeLine("<STATUS>", tabs=tabs)
+            self.writeLine("<CODE>{0}".format(
+                self.ofx.status['code']
+            ), tabs=tabs+1)
+            self.writeLine("<SEVERITY>{0}".format(
+                self.ofx.status['severity']
+            ), tabs=tabs+1)
+            self.writeLine("</STATUS>", tabs=tabs)
+        self.writeCCStmTrs(tabs=tabs)
+        tabs -= 1
+        self.writeLine("</CCSTMTTRNRS>", tabs=tabs)
+        tabs -= 1
+        self.writeLine("</CREDITCARDMSGSRSV1>", tabs=tabs)
+
     def writeOfx(self, tabs=0):
         self.writeLine("<OFX>", tabs=tabs)
         tabs += 1


### PR DESCRIPTION
This pull request includes changes to the `ofxparse` Python library, specifically in the `ofxparse.py` and `ofxprinter.py` files. The changes are centered around improving the handling of OFX data, including parsing and printing. The main changes include parsing the `dtserver` field in the `__init__` method of `ofxparse.py`, adding a `tabs` parameter in the `OfxPrinter` class of `ofxprinter.py`, and expanding the `writeHeaders`, `writeStmTrs`, and `writeBankMsgsRsv1` methods in `ofxprinter.py`.

Parsing improvements:
* [`ofxparse/ofxparse.py`](diffhunk://#diff-18803b5503c47d0ec761248e73401dffdfda89ef65edc3901718ded8a080fd79R262-R264): The `__init__` method now parses the `dtserver` field using the `parseOfxDateTime` method from `OfxParser`.

Printing improvements:
* [`ofxparse/ofxprinter.py`](diffhunk://#diff-a2d9852396ba79a32276e7ce6843695c247839464dd4bd5ccc6a7276918fa297L10-R21): The `OfxPrinter` class now has a `tabs` parameter in the `__init__` method, which is used to control the indentation of the output.
* [`ofxparse/ofxprinter.py`](diffhunk://#diff-a2d9852396ba79a32276e7ce6843695c247839464dd4bd5ccc6a7276918fa297L38-R68): The `writeSignOn` method has been expanded to handle a variety of fields and conditions for the `signon` object.
* [`ofxparse/ofxprinter.py`](diffhunk://#diff-a2d9852396ba79a32276e7ce6843695c247839464dd4bd5ccc6a7276918fa297R177-R214): A new method `writeCCStmTrs` has been added to handle the printing of credit card statement transactions.
* [`ofxparse/ofxprinter.py`](diffhunk://#diff-a2d9852396ba79a32276e7ce6843695c247839464dd4bd5ccc6a7276918fa297R239-R269): The `writeBankMsgsRsv1` method has been expanded to handle credit card messages via the new `writeCreditCardMsgsRsv1` method.